### PR TITLE
FileVault, recovery keys and more

### DIFF
--- a/ApfsLib/ApfsContainer.cpp
+++ b/ApfsLib/ApfsContainer.cpp
@@ -80,7 +80,12 @@ bool ApfsContainer::Init()
 	return true;
 }
 
-ApfsVolume * ApfsContainer::GetVolume(int index)
+ApfsVolume *ApfsContainer::GetVolume(int index)
+{
+  return GetVolume(index, std::string());
+}
+
+ApfsVolume *ApfsContainer::GetVolume(int index, const std::string &passphrase)
 {
 	ApfsVolume *vol = nullptr;
 	uint64_t nodeid;
@@ -89,6 +94,8 @@ ApfsVolume * ApfsContainer::GetVolume(int index)
 
 	if (index >= 100)
 		return nullptr;
+
+	m_passphrase = passphrase;
 
 	nodeid = m_sb.nodeid_apsb[index];
 
@@ -158,7 +165,19 @@ bool ApfsContainer::GetVolumeKey(uint8_t * key, const apfs_uuid_t & vol_uuid, co
 	if (!m_keymgr.IsValid())
 		return false;
 
-	return m_keymgr.GetVolumeKey(key, vol_uuid, password);
+	return m_keymgr.GetVolumeKey(key, vol_uuid, password, false);
+}
+
+bool ApfsContainer::GetVolumeKey(uint8_t *key, const apfs_uuid_t & vol_uuid)
+{
+	if (!m_keymgr.IsValid())
+		return false;
+
+	if (m_passphrase.empty()) {
+		return false;
+	}
+
+	return m_keymgr.GetVolumeKey(key, vol_uuid, m_passphrase.c_str(), true);
 }
 
 bool ApfsContainer::GetPasswordHint(std::string & hint, const apfs_uuid_t & vol_uuid)

--- a/ApfsLib/ApfsContainer.cpp
+++ b/ApfsLib/ApfsContainer.cpp
@@ -28,6 +28,7 @@
 #include "Global.h"
 
 int g_debug = 0;
+bool g_lax = false;
 
 #undef KEYBAG_DEBUG
 

--- a/ApfsLib/ApfsContainer.h
+++ b/ApfsLib/ApfsContainer.h
@@ -39,7 +39,8 @@ public:
 
 	bool Init();
 
-	ApfsVolume *GetVolume(int index);
+	ApfsVolume *GetVolume(int index, const std::string &passphrase);
+  ApfsVolume *GetVolume(int index);
 	int GetVolumeCnt() const;
 
 	bool ReadBlocks(byte_t *data, uint64_t blkid, uint64_t blkcnt = 1) const;
@@ -47,6 +48,7 @@ public:
 
 	uint32_t GetBlocksize() const { return m_sb.block_size; }
 
+	bool GetVolumeKey(uint8_t *key, const apfs_uuid_t &vol_uuid);
 	bool GetVolumeKey(uint8_t *key, const apfs_uuid_t &vol_uuid, const char *password);
 	bool GetPasswordHint(std::string &hint, const apfs_uuid_t &vol_uuid);
 
@@ -56,6 +58,9 @@ private:
 	Device &m_disk;
 	const uint64_t m_part_start;
 	const uint64_t m_part_len;
+	std::string m_passphrase;
+	std::string m_passphrase_kek_struct;
+	std::string m_volume_kek_struct;
 
 	APFS_Superblock_NXSB m_sb;
 

--- a/ApfsLib/ApfsDir.cpp
+++ b/ApfsLib/ApfsDir.cpp
@@ -302,10 +302,21 @@ bool ApfsDir::ReadFile(void* data, uint64_t inode, uint64_t offs, size_t size)
 			cur_size = ext_val->size - (idx << 12);
 		if (cur_size == 0)
 			break; // Die Freuden von Fuse ...
-		if (ext_val->block != 0)
-			m_vol.ReadBlocks(bdata, ext_val->block + idx, cur_size >> 12, true);
-		else
+		if (ext_val->block != 0) {
+			uint64_t block_id = ext_val->block;
+			m_vol.ReadBlocks(bdata, block_id + idx, cur_size >> 12, true,
+										   ext_val->crypto_id + idx);
+			if (g_debug > 8) {
+				std::cout << "reading at offset " << offs
+				  << " length " << cur_size
+					<< " starting from block " << block_id + idx
+					<< " (extent starts at block " << block_id
+					<< ")\n";
+			}
+		}
+		else {
 			memset(bdata, 0, cur_size);
+		}
 		bdata += cur_size;
 		offs += cur_size;
 		size -= cur_size;

--- a/ApfsLib/ApfsNodeMapperBTree.cpp
+++ b/ApfsLib/ApfsNodeMapperBTree.cpp
@@ -63,13 +63,18 @@ bool ApfsNodeMapperBTree::Init(uint64_t hdr_block_id, uint64_t version)
 
 	blk.resize(m_container.GetBlocksize());
 
-	if (!m_container.ReadAndVerifyHeaderBlock(blk.data(), hdr_block_id))
+	if (!m_container.ReadAndVerifyHeaderBlock(blk.data(), hdr_block_id)) {
+		std::cerr << "ERROR: header block NOT verified\n";
 		return false;
+	}
 
 	memcpy(&m_root_ptr, blk.data(), sizeof(APFS_Block_4_B_BTreeRootPtr));
 
-	if (m_root_ptr.hdr.type != 0x4000000B)
+	if (m_root_ptr.hdr.type != 0x4000000B) {
+		std::cerr << "ERROR: wrong header type 0x" << std::hex
+		    << m_root_ptr.hdr.type << "\n";
 		return false;
+	}
 
 	return m_tree.Init(m_root_ptr.entry[0].blk, version);
 }

--- a/ApfsLib/ApfsVolume.cpp
+++ b/ApfsLib/ApfsVolume.cpp
@@ -19,6 +19,7 @@
 
 #include <cstring>
 #include <vector>
+#include <iomanip>
 #include <iostream>
 
 #include "Global.h"
@@ -62,7 +63,9 @@ bool ApfsVolume::Init(uint64_t blkid_volhdr)
 	if (m_sb.signature != 0x42535041)
 		return false;
 
-	m_nodemap_dir.Init(m_sb.blockid_nodemap, m_sb.hdr.version);
+  if (!m_nodemap_dir.Init(m_sb.blockid_nodemap, m_sb.hdr.version)) {
+		std::cerr << "WARNING: m_nodemap_dir init failed\n";
+	}
 
 	if ((m_sb.flags_108 & 3) != 1)
 	{
@@ -71,25 +74,36 @@ bool ApfsVolume::Init(uint64_t blkid_volhdr)
 
 		std::cout << "Volume " << m_sb.vol_name << " is encrypted." << std::endl;
 
-		if (m_container.GetPasswordHint(str, m_sb.guid))
-			std::cout << "Hint: " << str << std::endl;
+		// Try self-service first
+		if (!m_container.GetVolumeKey(vek, m_sb.guid)) {
+			if (m_container.GetPasswordHint(str, m_sb.guid))
+				std::cout << "Hint: " << str << std::endl;
 
-		std::cout << "Enter Password: ";
-		GetPassword(str);
+			std::cout << "Enter Password: ";
+			GetPassword(str);
 
-		if (!m_container.GetVolumeKey(vek, m_sb.guid, str.c_str()))
-		{
-			std::cout << "Wrong password!" << std::endl;
-			return false;
+			if (!m_container.GetVolumeKey(vek, m_sb.guid, str.c_str()))
+			{
+				std::cout << "Wrong password!" << std::endl;
+				return false;
+			}
 		}
-
+		if (g_debug > 0) {
+    	std::cerr << "Setting the VEK and m_is_encrypted\n";
+		}
 		m_aes.SetKey(vek, vek + 0x10);
 		m_is_encrypted = true;
 	}
 
-	m_bt_directory.Init(m_sb.nodeid_rootdir, m_sb.hdr.version, &m_nodemap_dir);
-	m_bt_blockmap.Init(m_sb.blockid_blockmap, m_sb.hdr.version);
-	m_bt_snapshots.Init(m_sb.blockid_4xBx10_map, m_sb.hdr.version);
+  if(!m_bt_directory.Init(m_sb.nodeid_rootdir, m_sb.hdr.version, &m_nodemap_dir)) {
+		std::cerr << "WARNING: m_bt_directory init failed\n";
+	}
+	if (!m_bt_blockmap.Init(m_sb.blockid_blockmap, m_sb.hdr.version)) {
+		std::cerr << "WARNING: m_bt_blockmap init failed\n";
+	}
+	if (!m_bt_snapshots.Init(m_sb.blockid_4xBx10_map, m_sb.hdr.version)) {
+		std::cerr << "WARNING: m_bt_snapshots init failed\n";
+	}
 
 	return true;
 }

--- a/ApfsLib/ApfsVolume.cpp
+++ b/ApfsLib/ApfsVolume.cpp
@@ -51,7 +51,7 @@ bool ApfsVolume::Init(uint64_t blkid_volhdr)
 
 	blk.resize(m_container.GetBlocksize());
 
-	if (!ReadBlocks(blk.data(), blkid_volhdr, 1, false))
+	if (!ReadBlocks(blk.data(), blkid_volhdr, 1, false, 0)) // crypto_id is unused
 		return false;
 
 	if (!VerifyBlock(blk.data(), blk.size()))
@@ -100,7 +100,7 @@ void ApfsVolume::dump(BlockDumper& bd)
 
 	blk.resize(m_container.GetBlocksize());
 
-	if (!ReadBlocks(blk.data(), m_blockid_sb, 1, false))
+	if (!ReadBlocks(blk.data(), m_blockid_sb, 1, false, 0))
 		return;
 
 	if (!VerifyBlock(blk.data(), blk.size()))
@@ -116,7 +116,7 @@ void ApfsVolume::dump(BlockDumper& bd)
 	m_bt_snapshots.dump(bd);
 }
 
-bool ApfsVolume::ReadBlocks(byte_t * data, uint64_t blkid, uint64_t blkcnt, bool decrypt)
+bool ApfsVolume::ReadBlocks(byte_t * data, uint64_t blkid, uint64_t blkcnt, bool decrypt, uint64_t crypto_id)
 {
 	if (!m_container.ReadBlocks(data, blkid, blkcnt))
 		return false;
@@ -125,7 +125,7 @@ bool ApfsVolume::ReadBlocks(byte_t * data, uint64_t blkid, uint64_t blkcnt, bool
 		return true;
 
 	uint64_t cs_factor = m_container.GetBlocksize() / 0x200;
-	uint64_t uno = blkid * cs_factor;
+	uint64_t uno = crypto_id * cs_factor;
 	size_t size = blkcnt * m_container.GetBlocksize();
 	size_t k;
 

--- a/ApfsLib/ApfsVolume.h
+++ b/ApfsLib/ApfsVolume.h
@@ -46,7 +46,7 @@ public:
 
 	ApfsContainer &getContainer() const { return m_container; }
 
-	bool ReadBlocks(byte_t *data, uint64_t blkid, uint64_t blkcnt, bool decrypt);
+	bool ReadBlocks(byte_t *data, uint64_t blkid, uint64_t blkcnt, bool decrypt, uint64_t crypto_id);
 
 private:
 	ApfsContainer &m_container;

--- a/ApfsLib/BTree.cpp
+++ b/ApfsLib/BTree.cpp
@@ -189,8 +189,10 @@ bool BTree::Init(uint64_t root_node_id, uint64_t version, ApfsNodeMapper *node_m
 		memcpy(&m_treeinfo, m_root_node->block().data() + m_root_node->block().size() - sizeof(APFS_BTFooter), sizeof(APFS_BTFooter));
 		return true;
 	}
-	else
+	else {
+		std::cerr << "ERROR: could not find root_node_id " << root_node_id << "\n";
 		return false;
+	}
 }
 
 bool BTree::Lookup(BTreeEntry &result, const void *key, size_t key_size, BTCompareFunc func, void *context, bool exact)
@@ -378,8 +380,10 @@ std::shared_ptr<BTreeNode> BTree::GetNode(uint64_t nodeid, uint64_t parentid)
 
 		if (m_nodeid_map)
 		{
-			if (!m_nodeid_map->GetBlockID(ni, nodeid, m_version))
+			if (!m_nodeid_map->GetBlockID(ni, nodeid, m_version)) {
+				std::cerr << "ERROR: m_nodeid_map available, but no such nodeid\n";
 				return node;
+			}
 		}
 
 		blk.resize(m_container.GetBlocksize());
@@ -393,13 +397,18 @@ std::shared_ptr<BTreeNode> BTree::GetNode(uint64_t nodeid, uint64_t parentid)
 				return node;
 			}
 
-			if (!VerifyBlock(blk.data(), blk.size()))
+
+			if (!VerifyBlock(blk.data(), blk.size())) {
+				std::cerr << "ERROR: (volume) VerifyBlock failed\n";
 				return node;
+			}
 		}
 		else
 		{
-			if (!m_container.ReadAndVerifyHeaderBlock(blk.data(), ni.block_no))
+			if (!m_container.ReadAndVerifyHeaderBlock(blk.data(), ni.block_no)) {
+				std::cerr << "ERROR: ReadAndVerifyHeaderBlock failed\n";
 				return node;
+			}
 		}
 
 		node = BTreeNode::CreateNode(*this, blk.data(), blk.size(), parentid, ni.block_no);

--- a/ApfsLib/BTree.cpp
+++ b/ApfsLib/BTree.cpp
@@ -386,8 +386,12 @@ std::shared_ptr<BTreeNode> BTree::GetNode(uint64_t nodeid, uint64_t parentid)
 
 		if (m_volume)
 		{
-			if (!m_volume->ReadBlocks(blk.data(), ni.block_no, 1, (ni.flags & 4) != 0))
+			// TODO: is the crypto_id always equal to the block ID here?
+			if (!m_volume->ReadBlocks(blk.data(), ni.block_no, 1, (ni.flags & 4) != 0,
+			                          ni.block_no)) {
+				std::cerr << "ERROR: volume ReadBlocks failed\n";
 				return node;
+			}
 
 			if (!VerifyBlock(blk.data(), blk.size()))
 				return node;

--- a/ApfsLib/BlockDumper.cpp
+++ b/ApfsLib/BlockDumper.cpp
@@ -549,7 +549,7 @@ void BlockDumper::DumpBTEntry_0_E(const byte_t *key_data, size_t key_length, con
 	case 0x8:
 		assert(key_length == 16);
 		m_os << "Data " << key << " " << *reinterpret_cast<const uint64_t *>(key_data + 8) << " => ";
-		// key | offset : len | block | unk
+		// key | offset : len | block | crypto_id
 
 		m_os << hex;
 
@@ -565,7 +565,7 @@ void BlockDumper::DumpBTEntry_0_E(const byte_t *key_data, size_t key_length, con
 			if (value_length == 0x18)
 			{
 				const APFS_Extent *ext = reinterpret_cast<const APFS_Extent *>(value_data);
-				m_os << ext->size << " " << ext->block << " " << ext->unk << endl;
+				m_os << ext->size << " " << ext->block << " " << ext->crypto_id << endl;
 			}
 			else
 			{

--- a/ApfsLib/BlockDumper.h
+++ b/ApfsLib/BlockDumper.h
@@ -72,10 +72,10 @@ private:
 
 public:
 	static const char * GetNodeType(uint32_t type, uint32_t subtype);
+	static const std::string uuid(const apfs_uuid_t &uuid);
 
 private:
 	static const std::string tstamp(uint64_t apfs_time);
-	static const std::string uuid(const apfs_uuid_t &uuid);
 
 	uint32_t m_text_flags; // 00 - Alt, 01 - insensitive, 08 - sensitive
 

--- a/ApfsLib/Crypto.cpp
+++ b/ApfsLib/Crypto.cpp
@@ -59,7 +59,7 @@ void Rfc3394_KeyWrap(uint8_t *crypto, const uint8_t *plain, size_t size, const u
 		c[i + 1] = r[i];
 }
 
-void Rfc3394_KeyUnwrap(uint8_t *plain, const uint8_t *crypto, size_t size, const uint8_t *key, AES::Mode aes_mode, uint64_t *iv)
+bool Rfc3394_KeyUnwrap(uint8_t *plain, const uint8_t *crypto, size_t size, const uint8_t *key, AES::Mode aes_mode, uint64_t *iv)
 {
 	Rfc3394_Unit u;
 	uint64_t a;
@@ -96,6 +96,10 @@ void Rfc3394_KeyUnwrap(uint8_t *plain, const uint8_t *crypto, size_t size, const
 		p[i] = r[i];
 	if (iv)
 		*iv = a;
+	if (a == rfc_3394_default_iv)
+		return true;
+	else
+		return false;
 }
 
 void HMAC_SHA256(const uint8_t *key, size_t key_len, const uint8_t *data, size_t data_len, uint8_t *mac)

--- a/ApfsLib/Crypto.h
+++ b/ApfsLib/Crypto.h
@@ -5,6 +5,8 @@
 #include "Aes.h"
 
 void Rfc3394_KeyWrap(uint8_t *crypto, const uint8_t *plain, size_t size, const uint8_t *key, AES::Mode aes_mode, uint64_t iv);
-void Rfc3394_KeyUnwrap(uint8_t *plain, const uint8_t *crypto, size_t size, const uint8_t *key, AES::Mode aes_mode, uint64_t *iv);
+bool Rfc3394_KeyUnwrap(uint8_t *plain, const uint8_t *crypto, size_t size, const uint8_t *key, AES::Mode aes_mode, uint64_t *iv);
 void HMAC_SHA256(const uint8_t *key, size_t key_len, const uint8_t *data, size_t data_len, uint8_t *mac);
 void PBKDF2_HMAC_SHA256(const uint8_t* pw, size_t pw_len, const uint8_t* salt, size_t salt_len, int iterations, uint8_t* derived_key, size_t dk_len);
+
+const uint64_t rfc_3394_default_iv = 0xA6A6A6A6A6A6A6A6ULL;

--- a/ApfsLib/Decmpfs.cpp
+++ b/ApfsLib/Decmpfs.cpp
@@ -17,6 +17,7 @@
 	along with apfs-fuse.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <iomanip>
 #include <iostream>
 #include <cstring>
 #include <cassert>
@@ -30,6 +31,8 @@
 
 #include "FastCompression.h"
 #include "Global.h"
+#include "Util.h"
+
 
 struct RsrcForkHeader
 {
@@ -94,6 +97,19 @@ bool IsDecompAlgoInRsrc(uint16_t algo)
 	}
 }
 
+static size_t expected_block_len(int block_number, size_t uncompressed_file_size) {
+	const size_t uncompressed_block_standard_size = 0x10000;
+
+	int whole_blocks = uncompressed_file_size >> 16;
+	if (block_number < whole_blocks) {
+		return uncompressed_block_standard_size;
+	}
+	if (block_number == whole_blocks) {
+		return uncompressed_file_size % uncompressed_block_standard_size;
+	}
+	return 0;
+}
+
 bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompressed, const std::vector<uint8_t> &compressed)
 {
 #if 1
@@ -106,14 +122,22 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 
 	if (hdr->algo == 3)
 	{
-		if (g_debug > 0)
-			std::cout << "DecompressFile " << compressed.size() << " => " << hdr->size << std::endl;
+		if (g_debug > 8) {
+			std::cout << "DecompressFile " << compressed.size()
+				  << " => " << hdr->size << std::endl;
+    		}
 
 		decompressed.resize(hdr->size);
 
 		if (compressed[0x10] == 0x78)
 		{
-			DecompressZLib(decompressed.data(), decompressed.size(), cdata, csize);
+			size_t decoded_bytes = DecompressZLib(decompressed.data(), decompressed.size(), cdata, csize);
+			if (decoded_bytes != hdr->size) {
+				if (g_debug > 0)
+					std::cout << "Expected " << hdr->size << " bytes in compressed stream, "
+						  << "got " << decoded_bytes << std::endl;
+				return false;
+			}
 		}
 		else if (compressed[0x10] == 0xFF)
 		{
@@ -124,12 +148,24 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 	{
 		std::vector<uint8_t> rsrc;
 
-		bool rc = dir.GetAttribute(rsrc, ino, "com.apple.ResourceFork");
+		if (g_debug > 8) {
+			std::cout << "type=4: zlib in resource fork\n"
+		 		  << " stream info: size=" << compressed.size();
+			DumpBuffer(compressed.data(), compressed.size(), "decmpfs content");
+		}
 
+		bool rc = dir.GetAttribute(rsrc, ino, "com.apple.ResourceFork");
 		if (!rc)
 		{
+			if (g_debug > 0)
+				std::cout << "Could not read resource fork\n";
 			decompressed.clear();
 			return false;
+		}
+
+		if (g_debug > 8) {
+			std::cout << "read " << rsrc.size() <<" bytes from resource fork\n";
+			DumpBuffer(rsrc.data(), rsrc.size(), "rsrc content");
 		}
 
 		RsrcForkHeader rsrc_hdr;
@@ -140,30 +176,96 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 		rsrc_hdr.mgmt_off_be = bswap_32(rsrc_hdr.mgmt_off_be);
 		rsrc_hdr.mgmt_size_be = bswap_32(rsrc_hdr.mgmt_size_be);
 
-		// uint32_t rsrc_size = bswap_32(*reinterpret_cast<uint32_t *>(rsrc.data() + rsrc_hdr.data_off_be));
+		if (g_debug > 8) {
+			std::cout << "computed values:\n data offset=" << rsrc_hdr.data_off_be
+				<< "\n data size=" << rsrc_hdr.data_size_be
+				<< "\n mgmt offset=" << rsrc_hdr.mgmt_off_be
+				<< "\n mgmt size=" << rsrc_hdr.mgmt_size_be << "\n";
+		}
+
+		uint32_t rsrc_size = bswap_32(*reinterpret_cast<uint32_t *>(rsrc.data() + rsrc_hdr.data_off_be));
+		if (rsrc_hdr.data_off_be > rsrc.size()) {
+			if (g_debug > 0) {
+				std::cout << "invalid data offset in resource fork header\n";
+			}
+			return false;
+		}
 		const uint8_t *cmpf_rsrc_base = rsrc.data() + rsrc_hdr.data_off_be + sizeof(uint32_t);
 		const CmpfRsrc *cmpf_rsrc = reinterpret_cast<const CmpfRsrc *>(cmpf_rsrc_base);
 
 		decompressed.resize((hdr->size + 0xFFFF) & 0xFFFF0000);
 
-		uint8_t blk[0x10000];
+		if (g_debug > 8) {
+			std::cout << "Decompressed size according to header: " << hdr->size << "\n";
+		}
+
+		// Inflate may write past 0x10000 with incorrect input. This provides
+		// a safety margin of sorts.
+		uint8_t blk[0x40000];
 		size_t k;
 		size_t off = 0;
 
 		for (k = 0; k < cmpf_rsrc->entries; k++)
 		{
-			// DecompressZLib(decompressed.data() + 0x10000 * k, 0x10000, cmpf_rsrc_base + cmpf_rsrc->entry[k].off, cmpf_rsrc->entry[k].size);
-			off = DecompressZLib(blk, 0x10000, cmpf_rsrc_base + cmpf_rsrc->entry[k].off, cmpf_rsrc->entry[k].size);
+			size_t src_offset = cmpf_rsrc->entry[k].off;
+			const uint8_t *src = cmpf_rsrc_base + src_offset;
+			size_t src_len = cmpf_rsrc->entry[k].size;
+			size_t entry_last_offset = rsrc_hdr.data_off_be + src_offset + src_len - 1;
+			if (entry_last_offset > rsrc.size()) {
+				if (g_debug > 0) {
+					std::cout << "Invalid entry (k=" << k << ") in block map: "
+					          << "block size extends past end of resource fork\n";
+				}
+				return false;
+			}
 
-			if (g_debug > 0)
-				std::cout << "DecompressZLib dst = " << (0x10000 * k) << " / 10000 src = " << cmpf_rsrc->entry[k].off << " / " << cmpf_rsrc->entry[k].size << " => " << off << std::endl;
+			size_t expected = expected_block_len(k, hdr->size);
+			if ((src_len == 0x10001) || ((src[0] & 0x0f) == 0x0f)) {
+				// not compressed
+				src++;
+				src_len--;
+				if (src_len != expected) {
+					if (g_debug > 0)
+						std::cout << "Invalid content in block " << k << ": expected "
+						          << expected << " bytes, but uncompressed block has size "
+							  << src_len << std::endl;
+					return false;
+				}
+				memcpy(blk, src, src_len);
+			} else if (src_len > 0x10000) {
+				if (g_debug > 0) {
+					std::cout << "Invalid map entry: offset=" << src_offset
+						<< ", size=" << src_len << ".\n";
+				}
+				return false;
+			} else {
+
+				off = DecompressZLib(blk, 0x10000, cmpf_rsrc_base + cmpf_rsrc->entry[k].off, cmpf_rsrc->entry[k].size);
+
+				if (g_debug > 8)
+					std::cout << "DecompressZLib dst = " << (0x10000 * k) << " / 10000 src = " << cmpf_rsrc->entry[k].off << " / " << cmpf_rsrc->entry[k].size << " => " << off << std::endl;
+
+				if (off != expected) {
+					if (g_debug > 0)
+						std::cout << "Wrong uncompressed size for block " << k << ": expected "
+							  << expected << " bytes, found " << off << std::endl;
+					return false;
+				}
+
+				if ((0x10000 * (k + 1) - 1) > decompressed.size()) {
+						if (g_debug > 0) {
+							std::cout << "More decompressed data than expected!\n";
+						}
+						return false;
+				}
+			}
 
 			std::copy(blk, blk + 0x10000, decompressed.begin() + (0x10000 * k));
 		}
 	}
 	else if (hdr->algo == 7)
 	{
-		if (g_debug > 0)
+		if (g_debug > 8)
 			std::cout << "Decompress LZVN compressed file " << compressed.size() << " => " << hdr->size << std::endl;
 
 		decompressed.resize(hdr->size);
@@ -175,8 +277,8 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 	}
 	else if (hdr->algo == 8)
 	{
-		if (g_debug > 0)
-			std::cout << "Decompress LZVN compressed resource file ..." << std::endl;
+		if (g_debug > 8)
+			std::cout << "Decompress LZVN compressed resource file" << std::endl;
 
 		std::vector<uint8_t> rsrc;
 		size_t k;
@@ -191,10 +293,70 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 
 		const uint32_t *off_list = reinterpret_cast<const uint32_t *>(rsrc.data());
 
-		decompressed.resize((hdr->size + 0xFFFF) & 0xFFFF0000);
+		size_t decompressed_new_size = (hdr->size + 0xFFFF) & 0xFFFF0000;
 
-		for (k = 0; (k << 16) < decompressed.size(); k++)
-			lzvn_decode(decompressed.data() + (k << 16), 0x10000, rsrc.data() + off_list[k], off_list[k + 1] - off_list[k]);
+		decompressed.resize(decompressed_new_size);
+
+		if (g_debug > 8) {
+			std::cout << "rsrc data size = " << rsrc.size() << "\n";
+			std::cout << "hdr claims that size is " << hdr->size << "\n";
+			std::cout << "allocated: " << decompressed_new_size << "\n";
+		}
+
+		if (g_debug > 8)
+			DumpBuffer(rsrc.data(), rsrc.size(), "rsrc content");
+
+		for (k = 0; (k << 16) < decompressed.size(); k++) {
+			size_t k_offset = k << 16;
+			void *dst = decompressed.data() + k_offset;
+			size_t dst_len = 0x10000;
+			const uint8_t *src = rsrc.data() + off_list[k];
+			size_t src_len = off_list[k+1] - off_list[k];
+			size_t expected = expected_block_len(k, hdr->size);
+			if (g_debug > 8) {
+				std::cout << " k=" << k << ": off_list[k]=" << off_list[k] << "\n";
+				std::cout << " size=" << src_len;
+				std::cout << "\n";
+				std::cout.flush();
+			}
+			if ((off_list[k+1] < off_list[k]) || (off_list[k+1] > rsrc.size())) {
+				if (g_debug > 0) {
+					std::cout << "invalid offset\n";
+				}
+				return false;
+			}
+			// lzvn_decode(decompressed.data() + (k << 16), 0x10000, rsrc.data() + off_list[k], off_list[k + 1] - off_list[k]);
+			// if len == 0x10001 the block is not compressed!
+			// also, if src[0] == 0x06...
+			if (src_len == 0x10001 || src[0] == 0x06) {
+				src++;
+				src_len--;
+				if (src_len != expected) {
+					if (g_debug > 0)
+						std::cout << "Invalid content in block " << k << ": expected "
+						          << expected << " bytes, but uncompressed block has size "
+							  << src_len << std::endl;
+					return false;
+				}
+				memcpy(dst, src, src_len);
+			} else if (src_len > 0x10000) {
+				if (g_debug > 0) {
+					std::cout << "Invalid compressed block size";
+				}
+				return false;
+			}	else {
+				size_t decoded_size = lzvn_decode(dst, dst_len, src, src_len);
+				if (g_debug > 8) {
+					std::cout << "lzvn_decode got " << decoded_size << "\n";
+				}
+				if (decoded_size != expected) {
+					if (g_debug > 0)
+						std::cout << "Wrong uncompressed size for block " << k << ": expected "
+							  << expected << " bytes, found " << decoded_size << std::endl;
+					return false;
+				}
+			}
+		}
 
 		decompressed.resize(hdr->size);
 
@@ -205,6 +367,10 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 	{
 		if (g_debug > 0)
 			std::cout << "DecompressFile: Unknown Algorithm " << hdr->algo << std::endl;
+
+	  std::cerr << "Unknown algo " << hdr->algo << "\n";
+		std::cerr << "stream size: " << compressed.size() << "\n";
+		DumpBuffer(compressed.data(), compressed.size(), "compressed stream content");
 
 		decompressed = compressed;
 	}

--- a/ApfsLib/DiskStruct.h
+++ b/ApfsLib/DiskStruct.h
@@ -193,7 +193,7 @@ struct APFS_Extent
 {
 	uint64_t size;
 	uint64_t block;
-	uint64_t unk;
+	uint64_t crypto_id;
 };
 
 struct APFS_Key_Attribute

--- a/ApfsLib/Global.h
+++ b/ApfsLib/Global.h
@@ -24,3 +24,5 @@ typedef unsigned char apfs_uuid_t[16];
 
 // Debug level - defined in ApfsContainer.cpp
 extern int g_debug;
+// Lax mode - defined in ApfsContainer.cpp
+extern bool g_lax;

--- a/ApfsLib/KeyMgmt.cpp
+++ b/ApfsLib/KeyMgmt.cpp
@@ -1,10 +1,13 @@
 #include <cstring>
+#include <iomanip>
+#include <iostream>
 
 #include "ApfsContainer.h"
 #include "AesXts.h"
 #include "Sha256.h"
 #include "Crypto.h"
 #include "Util.h"
+#include "BlockDumper.h"
 
 #include "KeyMgmt.h"
 
@@ -66,6 +69,10 @@ struct vek_blob_t
 	uint8_t unk_82[8];
 	uint8_t wrapped_vek[0x28];
 };
+
+void dumpBagData(const bagdata_t &data, const char *label) {
+	DumpBuffer(data.data, data.size, label);
+}
 
 KeyParser::KeyParser()
 {
@@ -259,7 +266,7 @@ bool Keybag::GetKey(size_t nr, key_data_t & keydata)
 	return true;
 }
 
-bool Keybag::FindKey(const apfs_uuid_t & uuid, uint16_t type, key_data_t & keydata)
+bool Keybag::FindKey(const apfs_uuid_t & uuid, uint16_t type, key_data_t & keydata, int force_index)
 {
 	if (m_data.empty())
 		return false;
@@ -272,6 +279,45 @@ bool Keybag::FindKey(const apfs_uuid_t & uuid, uint16_t type, key_data_t & keyda
 	size_t k;
 
 	ptr = m_data.data() + 0x10;
+
+	// Dump all keys
+	if (g_debug > 0) {
+		for (k = 0; k < hdr.no_of_keys; k++)
+		{
+			khdr = reinterpret_cast<const key_hdr_t *>(ptr);
+			std::cout << "k=" << k << "; uuid=" << BlockDumper::uuid(khdr->uuid)
+					<< "; type=" << khdr->type << "\n";
+			len = (khdr->length + sizeof(key_hdr_t) + 0xF) & ~0xF;
+			ptr += len;
+		}
+		std::cout <<"\n";
+	}
+
+	// Actual work
+	ptr = m_data.data() + 0x10;
+
+	for (k = 0; k < hdr.no_of_keys; k++)
+	{
+		khdr = reinterpret_cast<const key_hdr_t *>(ptr);
+
+		if (
+			(force_index == k) ||
+			(force_index == -1
+					&& memcmp(uuid, khdr->uuid, sizeof(apfs_uuid_t)) == 0
+					&& khdr->type == type))
+		{
+			if (g_debug > 0)
+				std::cout << " found key: k=" << k << "\n";
+			keydata.header = khdr;
+			keydata.data.data = ptr + sizeof(key_hdr_t);
+			keydata.data.size = khdr->length;
+
+			return true;
+		}
+
+		len = (khdr->length + sizeof(key_hdr_t) + 0xF) & ~0xF;
+		ptr += len;
+	}
 
 	for (k = 0; k < hdr.no_of_keys; k++)
 	{
@@ -321,6 +367,11 @@ bool KeyManager::GetPasswordHint(std::string& hint, const apfs_uuid_t& volume_uu
 	key_data_t recs_block;
 	key_data_t hint_data;
 
+  if (g_debug > 0) {
+  	std::cout << "Password hint: looking for key type 3 for volume "
+        			<< BlockDumper::uuid(volume_uuid) << " in m_container_bag\n";
+  }
+
 	if (!m_container_bag.FindKey(volume_uuid, 3, recs_block))
 		return false;
 
@@ -331,8 +382,15 @@ bool KeyManager::GetPasswordHint(std::string& hint, const apfs_uuid_t& volume_uu
 
 	Keybag recs_bag;
 
+	if (g_debug > 0)
+	  std::cout << "Trying to load key bag from recs_block\n";
+
 	if (!LoadKeybag(recs_bag, 0x72656373, recs_ext.blk, recs_ext.bcnt, volume_uuid))
 		return false;
+
+  if (g_debug > 0)
+	  std::cout << "Password hint: looking for key type 4 for volume "
+			        << BlockDumper::uuid(volume_uuid) << " in recs_bag\n";
 
 	if (!recs_bag.FindKey(volume_uuid, 4, hint_data))
 		return false;
@@ -342,7 +400,7 @@ bool KeyManager::GetPasswordHint(std::string& hint, const apfs_uuid_t& volume_uu
 	return true;
 }
 
-bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, const char* password)
+bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, const char* password, bool password_is_prk)
 {
 	key_data_t recs_block;
 	key_data_t kek_header;
@@ -352,21 +410,51 @@ bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, cons
 	kek_blob_t kek_blob;
 	vek_blob_t vek_blob;
 
+  	if (g_debug > 0)
+		std::cout << "GetVolumeKey: looking for key type 3 for volume "
+		          << BlockDumper::uuid(volume_uuid) << " in m_container_bag\n";
+
 	if (!m_container_bag.FindKey(volume_uuid, 3, recs_block))
 		return false;
 
+	if (g_debug > 0)
+		std::cout << " key found\n";
+
 	if (recs_block.data.size != sizeof(key_extent_t))
 		return false;
+
+	if (g_debug > 0)
+		std::cout << " data size matches that of key_extent_t\n";
 
 	const key_extent_t &recs_ext = *reinterpret_cast<const key_extent_t *>(recs_block.data.data);
 
 	Keybag recs_bag;
 
+  	if (g_debug > 0)
+		std::cout << "Trying to load key bag from recs_block\n";
+
 	if (!LoadKeybag(recs_bag, 0x72656373, recs_ext.blk, recs_ext.bcnt, volume_uuid))
 		return false;
 
-	if (!recs_bag.FindKey(volume_uuid, 3, kek_header))
-		return false;
+	if (g_debug > 0)
+		std::cout << "key bag loaded\n";
+
+	if (password_is_prk) {
+		// TODO(epuccia): instead of looking for a specific key index, use
+		// the special personal recovery key UUID to identify it.
+		if (g_debug > 0)
+			std::cout << "GetVolumeKey: looking for key index 1 for volume "
+				  << BlockDumper::uuid(volume_uuid) << " in recs_bag\n";
+
+		if (!recs_bag.FindKey(volume_uuid, 3, kek_header, 1)) {
+			return false;
+		}
+	} else {
+		// password is a regular user password
+		if (!recs_bag.FindKey(volume_uuid, 3, kek_header)) {
+			return false;
+		}
+	}
 
 	if (!VerifyBlob(kek_header.data, kek_data))
 		return false;
@@ -374,11 +462,18 @@ bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, cons
 	if (!DecodeKEKBlob(kek_blob, kek_data))
 		return false;
 
+	if (g_debug > 0)
+		std::cout << "GetVolumeKey: looking for key type 2 for volume "
+	        	  << BlockDumper::uuid(volume_uuid) << " in m_container_bag\n";
+
 	if (!m_container_bag.FindKey(volume_uuid, 2, vek_header))
 		return false;
 
 	if (!VerifyBlob(vek_header.data, vek_data))
 		return false;
+
+	if (g_debug > 0)
+		dumpBagData(vek_data, "vek_data");
 
 	if (!DecodeVEKBlob(vek_blob, vek_data))
 		return false;
@@ -389,16 +484,64 @@ bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, cons
 	uint8_t kek[0x20];
 	uint64_t iv;
 
+	memset(vek, 0, 0x20);
+
+	if (g_debug > 0)
+		std::cout << " password check: pw is '" << password << "'; iterations="
+			  << kek_blob.iterations << "\n";
+
 	PBKDF2_HMAC_SHA256(reinterpret_cast<const uint8_t *>(password), strlen(password), kek_blob.salt, sizeof(kek_blob.salt), kek_blob.iterations, dk, sizeof(dk));
-	Rfc3394_KeyUnwrap(kek, kek_blob.wrapped_kek, 0x20, dk, AES::AES_256, &iv);
 
-	if (iv != 0xA6A6A6A6A6A6A6A6)
+	if (!Rfc3394_KeyUnwrap(kek, kek_blob.wrapped_kek, 0x20, dk, AES::AES_256, &iv)) {
+		if (g_debug > 0) {
+			DumpBuffer((uint8_t*)&iv, 8, "KEK IV");
+			DumpBuffer(kek, 32, "KEK content");
+		}
 		return false;
+	}
 
-	Rfc3394_KeyUnwrap(vek, vek_blob.wrapped_vek, 0x20, kek, AES::AES_256, &iv);
+  if (g_debug > 0)
+	  std::cout << " KEK IV valid\n";
 
-	if (iv != 0xA6A6A6A6A6A6A6A6)
+	DumpBuffer(vek_blob.wrapped_vek, 0x20, "wrapped VEK");
+
+	{
+		// Try AES-256 first. This method is used for wrapping the whole XTS-AES key,
+		// and applies to non-FileVault encrypted APFS volumes.
+		const size_t vek_len = 0x20;
+
+		if (Rfc3394_KeyUnwrap(vek, vek_blob.wrapped_vek, vek_len, kek, AES::AES_256, &iv))
+			return true;
+
+		// This didn't work; try the FileVault method.
+		if (g_debug > 0) {
+			DumpBuffer((uint8_t*)&iv, 8, "VEK IV (method 1)");
+			DumpBuffer(vek, vek_len, "VEK method 1");
+		}
+	}
+
+	const size_t vek_len = 0x10;
+	if (!Rfc3394_KeyUnwrap(vek, vek_blob.wrapped_vek, vek_len, kek, AES::AES_128, &iv)) {
+		if (g_debug > 0) {
+			DumpBuffer((uint8_t*)&iv, 8, "VEK IV (method 2)");
+			DumpBuffer(vek, vek_len, "VEK (method 2)");
+		}
 		return false;
+	}
+
+	// Tweak key calculation
+	SHA256 sha;
+	uint8_t sha_result[0x20];
+	sha.Init();
+
+	// Use (VEK || vek_blob.uuid), then SHA256, then take the first 16 bytes
+	sha.Update(vek, 0x10);
+	sha.Update(vek_blob.uuid, 0x10);
+	sha.Final(sha_result);
+	memcpy(&vek[0x10], sha_result, 0x10);
+
+	if (g_debug > 0)
+  	DumpBuffer(vek, 0x20, "final VEK");
 
 	return true;
 }
@@ -408,6 +551,9 @@ bool KeyManager::LoadKeybag(Keybag& bag, uint32_t type, uint64_t block, uint64_t
 	std::vector<uint8_t> data;
 	size_t k;
 	const size_t blocksize = m_container.GetBlocksize();
+
+	if (g_debug > 0)
+		std::cout << "starting LoadKeybag\n";
 
 	data.resize(blockcnt * blocksize);
 
@@ -421,7 +567,13 @@ bool KeyManager::LoadKeybag(Keybag& bag, uint32_t type, uint64_t block, uint64_t
 			return false;
 	}
 
+	if (g_debug > 0)
+  	std::cout << " all blocks verified\n";
+
 	const APFS_BlockHeader &hdr = *reinterpret_cast<const APFS_BlockHeader *>(data.data());
+
+	if (g_debug > 0)
+	  std::cout << " header has type " << std::hex << hdr.type << "\n";
 
 	if (hdr.type != type)
 		return false;
@@ -517,11 +669,15 @@ bool KeyManager::DecodeKEKBlob(kek_blob_t & kek_blob, const bagdata_t & data)
 
 	parser.SetData(key_hdr);
 
+	DumpBuffer(data.data, data.size, "KEK blob data");
+
 	if (!parser.GetUInt64(0x80, kek_blob.unk_80))
 		return false;
 
 	if (!parser.GetBytes(0x81, kek_blob.uuid, 0x10))
 		return false;
+
+	DumpBuffer(kek_blob.uuid, 0x10, "KEK blob UUID");
 
 	if (!parser.GetBytes(0x82, kek_blob.unk_82, 8))
 		return false;
@@ -544,6 +700,8 @@ bool KeyManager::DecodeVEKBlob(vek_blob_t & vek_blob, const bagdata_t & data)
 	bagdata_t key_hdr;
 
 	parser.SetData(data);
+
+	DumpBuffer(data.data, data.size, "VEK blob data");
 
 	if (!parser.GetAny(0xA3, key_hdr))
 		return false;

--- a/ApfsLib/KeyMgmt.cpp
+++ b/ApfsLib/KeyMgmt.cpp
@@ -500,10 +500,10 @@ bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, cons
 		return false;
 	}
 
-  if (g_debug > 0)
-	  std::cout << " KEK IV valid\n";
-
-	DumpBuffer(vek_blob.wrapped_vek, 0x20, "wrapped VEK");
+  	if (g_debug > 0) {
+		std::cout << " KEK IV valid\n";
+    		DumpBuffer(vek_blob.wrapped_vek, 0x20, "wrapped VEK");
+	}
 
 	{
 		// Try AES-256 first. This method is used for wrapping the whole XTS-AES key,
@@ -541,7 +541,7 @@ bool KeyManager::GetVolumeKey(uint8_t* vek, const apfs_uuid_t& volume_uuid, cons
 	memcpy(&vek[0x10], sha_result, 0x10);
 
 	if (g_debug > 0)
-  	DumpBuffer(vek, 0x20, "final VEK");
+	  	DumpBuffer(vek, 0x20, "final AES-XTS key");
 
 	return true;
 }
@@ -669,7 +669,8 @@ bool KeyManager::DecodeKEKBlob(kek_blob_t & kek_blob, const bagdata_t & data)
 
 	parser.SetData(key_hdr);
 
-	DumpBuffer(data.data, data.size, "KEK blob data");
+	if (g_debug > 0)
+  		DumpBuffer(data.data, data.size, "KEK blob data");
 
 	if (!parser.GetUInt64(0x80, kek_blob.unk_80))
 		return false;
@@ -677,7 +678,8 @@ bool KeyManager::DecodeKEKBlob(kek_blob_t & kek_blob, const bagdata_t & data)
 	if (!parser.GetBytes(0x81, kek_blob.uuid, 0x10))
 		return false;
 
-	DumpBuffer(kek_blob.uuid, 0x10, "KEK blob UUID");
+	if (g_debug > 0)
+  		DumpBuffer(kek_blob.uuid, 0x10, "KEK blob UUID");
 
 	if (!parser.GetBytes(0x82, kek_blob.unk_82, 8))
 		return false;
@@ -701,7 +703,8 @@ bool KeyManager::DecodeVEKBlob(vek_blob_t & vek_blob, const bagdata_t & data)
 
 	parser.SetData(data);
 
-	DumpBuffer(data.data, data.size, "VEK blob data");
+	if (g_debug > 0)
+		DumpBuffer(data.data, data.size, "VEK blob data");
 
 	if (!parser.GetAny(0xA3, key_hdr))
 		return false;

--- a/ApfsLib/KeyMgmt.h
+++ b/ApfsLib/KeyMgmt.h
@@ -59,7 +59,7 @@ public:
 
 	size_t GetKeyCnt();
 	bool GetKey(size_t nr, key_data_t &keydata);
-	bool FindKey(const apfs_uuid_t &uuid, uint16_t type, key_data_t &keydata);
+	bool FindKey(const apfs_uuid_t &uuid, uint16_t type, key_data_t &keydata, int force_index = -1);
 
 private:
 	std::vector<uint8_t> m_data;
@@ -74,7 +74,7 @@ public:
 	bool Init(uint64_t block, uint64_t blockcnt, const apfs_uuid_t &container_uuid);
 
 	bool GetPasswordHint(std::string &hint, const apfs_uuid_t &volume_uuid);
-	bool GetVolumeKey(uint8_t *vek, const apfs_uuid_t &volume_uuid, const char *password);
+	bool GetVolumeKey(uint8_t *vek, const apfs_uuid_t &volume_uuid, const char *password = NULL, bool password_is_prk = false);
 
 	bool IsValid() const { return m_is_valid; }
 

--- a/ApfsLib/Util.cpp
+++ b/ApfsLib/Util.cpp
@@ -362,3 +362,9 @@ bool GetPassword(std::string &pw)
 
 	return true;
 }
+
+// Like DumpHex, but prints a label.
+void DumpBuffer(const uint8_t *data, size_t len, const char *label) {
+	std::cout << "dumping " << label << "\n";
+	DumpHex(std::cout, data, len);
+}

--- a/ApfsLib/Util.cpp
+++ b/ApfsLib/Util.cpp
@@ -353,7 +353,7 @@ bool GetPassword(std::string &pw)
 		return false;
 
 	/* Read the password. */
-	std::cin >> pw;
+	std::getline(std::cin, pw);
 
 	/* Restore terminal. */
 	(void) tcsetattr (fileno (stream), TCSAFLUSH, &told);

--- a/ApfsLib/Util.h
+++ b/ApfsLib/Util.h
@@ -30,6 +30,7 @@ bool VerifyBlock(const void *block, size_t size);
 bool IsZero(const byte_t *data, size_t size);
 bool IsEmptyBlock(const void *data, size_t blksize);
 void DumpHex(std::ostream &os, const byte_t *data, size_t size, size_t line_size = 16);
+void DumpBuffer(const uint8_t *data, size_t len, const char *label);
 
 uint32_t HashFilename(const char *utf8str, uint16_t name_len, bool case_insensitive);
 bool GetPassword(std::string &pw);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.5)
 # set(CMAKE_C_COMPILER "clang")
 # set(CMAKE_CXX_COMPILER "clang++")
 
@@ -6,7 +6,7 @@ project(Apfs)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -march=native")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++11 -Wall -Wextra -march=native")
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Supported options:
 * `-d n`: If n > 0, enable debug output.
 * `-o opts`: Comma-separated list of mount options.
 * `-v n`: Instead of mounting the first volume in a container, mount volume n (starting at 0).
+* `-r recovery_key`: Mount an encrypted volume by supplying a Personal Recovery Key.
+* `-s n`: Find the container at offset n inside the device. This is useful when using an image file
+  instead of a disk device, and therefore partitions are not exposed.
 
 The device has to be the one containing the APFS container. If a container contains more than one volume,
 the volume can be specified by the `-v` option.

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ apfs-fuse <device> <mount-directory>
 Supported options:
 * `-d n`: If n > 0, enable debug output.
 * `-o opts`: Comma-separated list of mount options.
+* `-l`: Lax mode: when unexpected data is encountered, try to continue, even if this means
+  data returning potentially incorrect data.
 * `-v n`: Instead of mounting the first volume in a container, mount volume n (starting at 0).
-* `-r recovery_key`: Mount an encrypted volume by supplying a Personal Recovery Key.
+* `-r recovery_key`: Mount an encrypted volume by supplying a Personal Recovery Key (PRK).
 * `-s n`: Find the container at offset n inside the device. This is useful when using an image file
   instead of a disk device, and therefore partitions are not exposed.
 
 The device has to be the one containing the APFS container. If a container contains more than one volume,
 the volume can be specified by the `-v` option.
 
-If a volume is encrypted, the apfs-fuse command will prompt for a password.
+If a volume is encrypted, the apfs-fuse command will prompt for a password, unless a PRK is specified.
 
 ### Unmount a drive
 ```

--- a/apfsfuse/ApfsFuse.cpp
+++ b/apfsfuse/ApfsFuse.cpp
@@ -337,6 +337,11 @@ static void apfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi)
 				return;
 			}
 
+						if (g_debug > 0) {
+							std::cout << "Reporting size as [no stat]"
+								<< "\nHowever inode says: size=" << f->ino.sizes.size << ", size_on_disk="
+								<< f->ino.sizes.size_on_disk << "\n";
+						}
 			DecompressFile(dir, ino, f->decomp_data, attr);
 		}
 
@@ -536,7 +541,7 @@ int main(int argc, char *argv[])
 	const char *dev_path = nullptr;
 	int err = -1;
 	int opt;
-	std::string mount_options;
+	std::string mount_options, passphrase;
 	unsigned int volume_id = 0;
 
 	// static const char *dev_path = "/mnt/data/Projekte/VS17/Apfs/Data/ios_11_0_1.img";
@@ -561,7 +566,7 @@ int main(int argc, char *argv[])
 	ops.releasedir = apfs_releasedir;
 	// ops.statfs = apfs_statfs;
 
-	while ((opt = getopt(argc, argv, "d:o:v:")) != -1)
+	while ((opt = getopt(argc, argv, "d:o:v:r:")) != -1)
 	{
 		switch (opt)
 		{
@@ -573,6 +578,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'v':
 				volume_id = strtoul(optarg, nullptr, 10);
+				break;
+			case 'r':
+			  passphrase = std::string(optarg);
 				break;
 			default:
 				usage(argv[0]);
@@ -599,7 +607,7 @@ int main(int argc, char *argv[])
 	}
 	g_container = new ApfsContainer(g_disk, 0, g_disk.GetSize());
 	g_container->Init();
-	g_volume = g_container->GetVolume(volume_id);
+	g_volume = g_container->GetVolume(volume_id, passphrase);
 	if (!g_volume)
 	{
 		std::cerr << "Unable to get volume!" << std::endl;

--- a/apfsfuse/ApfsFuse.cpp
+++ b/apfsfuse/ApfsFuse.cpp
@@ -254,7 +254,8 @@ static void apfs_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size)
 	{
 		for (size_t k = 0; k < names.size(); k++)
 		{
-			std::cout << names[k] << std::endl;
+			if (g_debug > 0)
+				std::cout << names[k] << std::endl;
 			reply.append(names[k]);
 			reply.push_back(0);
 		}

--- a/apfsfuse/ApfsFuse.cpp
+++ b/apfsfuse/ApfsFuse.cpp
@@ -337,11 +337,10 @@ static void apfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi)
 				return;
 			}
 
-						if (g_debug > 0) {
-							std::cout << "Reporting size as [no stat]"
-								<< "\nHowever inode says: size=" << f->ino.sizes.size << ", size_on_disk="
-								<< f->ino.sizes.size_on_disk << "\n";
-						}
+			if (g_debug > 0) {
+				std::cout << "Inode info: size=" << f->ino.sizes.size
+				          << ", size_on_disk=" << f->ino.sizes.size_on_disk << "\n";
+			}
 			DecompressFile(dir, ino, f->decomp_data, attr);
 		}
 


### PR DESCRIPTION
Hi Simon!

Thank you very much for your apfs-fuse work!

I wanted to be able to use it to mount encrypted APFS volumes that have a recovery key, so I started implementing that functionality; then I also fixed some bits that I encountered as I went on.

The main changes in these commits are:

1. Allow mounting of FileVault-encrypted APFS volumes, as opposed to regular encrypted volumes;
1. Allow decryption through a (personal, not institutional) recovery key, as opposed to a regular password;
1. Fix decryption when an extent's crypto_id does not match the block number;
1. Fix reading fragmented files;
1. Fix decompression for several algos, especially the handling of uncompressed blocks;
1. Provide a "strict" mode that returns errors when decompression fails;
1. Minor enhancements (allow spaces in passwords; allow specifying a container offset, which is handy when working with raw disk images).

I'd very much like to have this functionality integrated upstream. Would you consider that? Is there something else you'd like me to do? I'll do my best to meet your requirements for that (e.g. style changes, split PRs, different code, you name it.)

Thanks again!