### PR TITLE
libattr header may not be present. Recommend updating ApfsFuse.cpp to use glibc xattr.h and ENODATA

### DIFF
--- a/apfsfuse/ApfsFuse.cpp
+++ b/apfsfuse/ApfsFuse.cpp
@@ -33,7 +33,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #ifdef __linux__
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #endif
 
 #include <ApfsLib/ApfsContainer.h>
@@ -249,7 +249,7 @@ static void apfs_getxattr_mac(fuse_req_t req, fuse_ino_t ino, const char *name, 
 		std::cout << (rc ? "OK" : "FAIL") << std::endl;
 
 	if (!rc)
-		fuse_reply_err(req, ENOATTR);
+		fuse_reply_err(req, ENODATA);
 	else
 	{
 		if (size == 0)
@@ -275,7 +275,7 @@ static void apfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name, size
 		std::cout << (rc ? "OK" : "FAIL") << std::endl;
 
 	if (!rc)
-		fuse_reply_err(req, ENOATTR);
+		fuse_reply_err(req, ENODATA);
 	else
 	{
 		if (size == 0)


### PR DESCRIPTION
glibc header and libattr header are virtually identical with the exception that ENOATTR is an alias in libattr for ENODATA errno. The libattr header is not always present on Linux, but the glibc header should nearly always be - especially if the user is building from source. Replacing attr/xattr.h with sys/xattr.h and ENOATTR with ENODATA.