### PR TITLE
Fix compilation errors

### DIFF
--- a/ApfsLib/Unicode.h
+++ b/ApfsLib/Unicode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 int normalizeOptFoldU32Char(char32_t ch, bool case_insensitive, char32_t *sequence_out, unsigned char *unknown_out);

--- a/ApfsLib/Unicode.h
+++ b/ApfsLib/Unicode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdlib>
+#include <cstddef>
 #include <vector>
 
 int normalizeOptFoldU32Char(char32_t ch, bool case_insensitive, char32_t *sequence_out, unsigned char *unknown_out);

--- a/ApfsLib/Util.h
+++ b/ApfsLib/Util.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdlib>
+#include <cstddef>
 #include <string>
 #include <ostream>
 #include <vector>

--- a/ApfsLib/Util.h
+++ b/ApfsLib/Util.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 #include <ostream>
 #include <vector>


### PR DESCRIPTION
On some systems, compilation raises an error indicating size_t is not
defined. Adding <cstdlib> to some headers fixes the issue.

This patch fixes issue #59 