### PR TITLE
Fixes compilation error: ‘unique_ptr’ is not a member of ‘std’

### DIFF
--- a/ApfsDump/Apfs.cpp
+++ b/ApfsDump/Apfs.cpp
@@ -17,6 +17,7 @@
 	along with apfs-fuse.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <memory>
 #include <fstream>
 #include <iostream>
 #include <iomanip>

--- a/ApfsDumpQuick/ApfsDumpQuick.cpp
+++ b/ApfsDumpQuick/ApfsDumpQuick.cpp
@@ -17,6 +17,7 @@
 	along with apfs-fuse.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <memory>
 #include <cstring>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
```
apfs-fuse/ApfsDump/Apfs.cpp:413:2:` error: ‘unique_ptr’ is not a member of ‘std’
  std::unique_ptr<Device> dev_main;
  ^
```
This was on ubuntu 14.04.