### PR TITLE
Fix for Ubuntu 14.04 compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(Apfs)
 
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -march=native")


### PR DESCRIPTION
Fixes this compilation error:
```
/home/class/apfs-fuse2/apfs-fuse/3rdparty/lzfse/src/lzfse_fse.h:564:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (int i = 0; i < table_size; i++) {
   ^
/home/class/apfs-fuse2/apfs-fuse/3rdparty/lzfse/src/lzfse_fse.h:564:3: note: use option -std=c99 or -std=gnu99 to compile your code
make[2]: *** [CMakeFiles/lzfse.dir/3rdparty/lzfse/src/lzfse_decode.c.o] Error 1
make[1]: *** [CMakeFiles/lzfse.dir/all] Error 2
make: *** [all] Error 2
```