### PR TITLE
Adding support for compression type 9

### DIFF
--- a/ApfsLib/Decmpfs.cpp
+++ b/ApfsLib/Decmpfs.cpp
@@ -58,6 +58,7 @@ bool IsDecompAlgoSupported(uint16_t algo)
 	case 4:
 	case 7:
 	case 8:
+    case 9:
 		return true;
 	default:
 		return false;
@@ -97,6 +98,7 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 		case 4: std::cout << " (Zlib, Rsrc)"; break;
 		case 7: std::cout << " (LZVN, Attr)"; break;
 		case 8: std::cout << " (LZVN, Rsrc)"; break;
+        case 9: std::cout << " (uncompressed, Attr)"; break;
 		default: std::cout << " (Unknown)"; break;
 		}
 
@@ -263,7 +265,12 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 				decoded_bytes = DecompressLZVN(decompressed.data(), decompressed.size(), cdata, csize);
 			}
 		}
-
+        else if (hdr->algo == 9)
+        {
+            assert(hdr->size == csize - 1);
+            decompressed.assign(cdata + 1, cdata + csize);
+            decoded_bytes = decompressed.size();
+        }
 		if (decoded_bytes != hdr->size)
 		{
 			if (g_debug & Dbg_Errors)

--- a/ApfsLib/Decmpfs.cpp
+++ b/ApfsLib/Decmpfs.cpp
@@ -58,7 +58,7 @@ bool IsDecompAlgoSupported(uint16_t algo)
 	case 4:
 	case 7:
 	case 8:
-    case 9:
+	case 9:
 		return true;
 	default:
 		return false;
@@ -98,7 +98,7 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 		case 4: std::cout << " (Zlib, Rsrc)"; break;
 		case 7: std::cout << " (LZVN, Attr)"; break;
 		case 8: std::cout << " (LZVN, Rsrc)"; break;
-        case 9: std::cout << " (uncompressed, Attr)"; break;
+		case 9: std::cout << " (uncompressed, Attr)"; break;
 		default: std::cout << " (Unknown)"; break;
 		}
 
@@ -265,12 +265,12 @@ bool DecompressFile(ApfsDir &dir, uint64_t ino, std::vector<uint8_t> &decompress
 				decoded_bytes = DecompressLZVN(decompressed.data(), decompressed.size(), cdata, csize);
 			}
 		}
-        else if (hdr->algo == 9)
-        {
-            assert(hdr->size == csize - 1);
-            decompressed.assign(cdata + 1, cdata + csize);
-            decoded_bytes = decompressed.size();
-        }
+		else if (hdr->algo == 9)
+		{
+			assert(hdr->size == csize - 1);
+			decompressed.assign(cdata + 1, cdata + csize);
+			decoded_bytes = decompressed.size();
+		}
 		if (decoded_bytes != hdr->size)
 		{
 			if (g_debug & Dbg_Errors)


### PR DESCRIPTION
Hi Simon

Thank you for your great work!

While working on a project with disk images from an IPSW file for iOS, I encountered entries with compression type 9, after quick research I found these are non-compressed files. The source I found is a comment in a source code for [copyfile](https://opensource.apple.com/source/copyfile) from apple, I have quoted the snippet below from https://opensource.apple.com/source/copyfile/copyfile-173.40.2/copyfile.c.auto.html

> ```c++
> switch (OSSwapLittleToHostInt32(hdr->compression_type)) {
>     ...
> 
>     case 9:  /* uncompressed data in xattr (similar to but not identical to CMP_Type1) */
>     case 10: /* 64k chunked uncompressed data in resource fork */
> 
>     ...
> ```

I made a minor addition to add the support for compression type 9 and it worked perfectly. I hope someone else might find it useful as well. 

Thanks 