### PR TITLE
Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Example for Linux:
 ```
 sudo apt update
 sudo apt install fuse libfuse3-dev bzip2 libbz2-dev cmake gcc-c++ git libattr1-dev zlib1g-dev
+sudo apt install build-essential
 ```
 Of course these commands depend on the Linux distribution.
 


### PR DESCRIPTION
To build apfs-fuse, I also had to install the packages from build-essential. I would always receive an error that "gcc-c++ could not be found" (this was on Ubuntu 22.04 and Xubuntu 22.04).

Amazing, amazing software by the way. Thank you so much for creating this, it has helped me so much with moving my encrypted apfs drives to ext4. Thank you! If there is a way for me to donate some money, please let me know!