### PR TITLE
fix: don't delete operating system when installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Development tools:
 Example for Linux:
 ```
 sudo apt update
-sudo apt install fuse libfuse3-dev bzip2 libbz2-dev cmake gcc-c++ git libattr1-dev zlib1g-dev
+sudo apt install fuse3 libfuse3-dev bzip2 libbz2-dev cmake gcc-c++ git libattr1-dev zlib1g-dev
 ```
 Of course these commands depend on the Linux distribution.
 


### PR DESCRIPTION

Summary:
On Ubuntu 22.04, attempt to install the `fuse` package will remove the
operating system. This is because the `fuse` package is now `fuse3`. This diff
updates the README to reflect this change.

Trying to install `fuse` on Ubuntu 22.04 conflicts with `fuse3` and will
uninstall `fuse3` along with the packages that depend on it.  On my Ubuntu
system, this was:

```sh
$ sudo apt install fuse

The following packages will be REMOVED:
  fuse3 gnome-control-center gnome-remote-desktop gnome-shell-extension-desktop-icons-ng gvfs-fuse ntfs-3g ubuntu-desktop ubuntu-desktop-minimal xdg-desktop-portal xdg-desktop-portal-gnome
  xdg-desktop-portal-gtk
The following NEW packages will be installed:
  fuse
0 upgraded, 1 newly installed, 11 to remove and 22 not upgraded.
```


Test Plan:
1. follow step 1 in the Usage section of the README
2. verify that operating system is not deleted
